### PR TITLE
Set tmp dataset to 1777 permissions

### DIFF
--- a/themelios
+++ b/themelios
@@ -273,6 +273,7 @@ mount_create_datasets() {
     zfs create -o mountpoint=none -o canmount=off "$zfs_pool_name/TMP"
     zfs create -o mountpoint=legacy -o canmount=on -o sync=disabled "$zfs_pool_name/TMP/tmp"
     mount -t zfs "$zfs_pool_name/TMP/tmp" /mnt/tmp
+    chmod 1777 /mnt/tmp
 
     zfs_auto_snapshot() {
         for dataset in "${zfs_auto_snapshot[@]}"


### PR DESCRIPTION
Default permissions seem to cause issues with the X server (It doesn't load the desktop after logging in: xfce will simply stall, but plasma5 will actually show an error for access denied to /tmp).