### PR TITLE
Added optional install arguments

### DIFF
--- a/hosts/vm-example/configuration.sh
+++ b/hosts/vm-example/configuration.sh
@@ -3,6 +3,7 @@
 use_sgdisk_clear="true"     # use sgdisk --clear
 use_wipefs_all="true"       # use wipefs --all
 use_zero_disks="false"      # use dd if=/dev/zero ...
+install_arguments=""        # any extra arguments to nixos-install, like --no-root-passwd
 zfs_pool_name="rpool"
 zfs_pool_disks=("/dev/sda") # Note: using /dev/disk/by-id is also preferable.
 zfs_pool_type=""            # use "" for single, or "mirror", "raidz1", etc.

--- a/themelios
+++ b/themelios
@@ -415,7 +415,7 @@ EOF
 
     # give user a retry option with --show-trace to have a chance to fix imports on another tty. :)
     nixos-install-show-trace() {
-        nixos-install --show-trace || nixos-install_fail_retry
+        nixos-install $install_arguments --show-trace || nixos-install_fail_retry
     }
 
     nixos-install_fail_retry() {
@@ -432,7 +432,7 @@ EOF
 
     install() {
         echo "executing nixos-install"
-        nixos-install || nixos-install_fail_retry
+        nixos-install $install_arguments || nixos-install_fail_retry
     }
 
     install


### PR DESCRIPTION
It's nice to have an option to add additional arguments to nixos-install as sometimes it doesn't realize options like users.mutableUsers = false; are set and prompts anyways.